### PR TITLE
`docker build`エラーの修正

### DIFF
--- a/superbook-pdf/docker/backend/Dockerfile
+++ b/superbook-pdf/docker/backend/Dockerfile
@@ -23,8 +23,8 @@ RUN rm -rf src
 
 # Copy actual source
 COPY src ./src
-COPY benches ./benches 2>/dev/null || true
-COPY tests ./tests 2>/dev/null || true
+COPY benches ./benches
+COPY tests ./tests
 
 # Build release binary
 RUN touch src/main.rs && cargo build --release --features web

--- a/superbook-pdf/docker/backend/Dockerfile.rocm
+++ b/superbook-pdf/docker/backend/Dockerfile.rocm
@@ -23,8 +23,8 @@ RUN rm -rf src
 
 # Copy actual source
 COPY src ./src
-COPY benches ./benches 2>/dev/null || true
-COPY tests ./tests 2>/dev/null || true
+COPY benches ./benches
+COPY tests ./tests
 
 # Build release binary
 RUN touch src/main.rs && cargo build --release --features web


### PR DESCRIPTION
docker buildエラーの修正です。

COPY構文は`COPY SRC DEST`の形式のみを受け付けるため今のコードはエラーになります。
https://docs.docker.jp/engine/reference/builder.html#copy