### PR TITLE
feat: Markdown変換機能（図コンテンツトリミング付き）

### DIFF
--- a/superbook-pdf/src/figure_detect.rs
+++ b/superbook-pdf/src/figure_detect.rs
@@ -1,0 +1,522 @@
+//! Figure detection module for scanned book pages
+//!
+//! Detects figures, full-page images, and covers in scanned book pages
+//! using connected component analysis and texture analysis.
+
+use image::{DynamicImage, GrayImage, Luma};
+use imageproc::contours::{find_contours, BorderType};
+use thiserror::Error;
+
+use crate::yomitoku::{OcrResult, TextBlock};
+
+/// Error type for figure detection
+#[derive(Debug, Error)]
+pub enum FigureDetectError {
+    #[error("Image loading failed: {0}")]
+    ImageLoadFailed(String),
+
+    #[error("Processing error: {0}")]
+    ProcessingError(String),
+
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+}
+
+/// Type of detected region
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegionType {
+    /// In-page figure (diagram, chart, photo)
+    Figure,
+    /// Full-page image (entire page is an image)
+    FullPageImage,
+    /// Cover page
+    Cover,
+}
+
+/// A detected figure region
+#[derive(Debug, Clone)]
+pub struct FigureRegion {
+    /// Bounding box: (x, y, width, height)
+    pub bbox: (u32, u32, u32, u32),
+    /// Area in pixels
+    pub area: u32,
+    /// Type of detected region
+    pub region_type: RegionType,
+}
+
+/// Page classification result
+#[derive(Debug, Clone)]
+pub enum PageClassification {
+    /// Cover page (first page, mostly image)
+    Cover,
+    /// Full-page image with no significant text
+    FullPageImage,
+    /// Mixed content: text with embedded figures
+    Mixed { figures: Vec<FigureRegion> },
+    /// Text-only page
+    TextOnly,
+}
+
+/// Options for figure detection
+#[derive(Debug, Clone)]
+pub struct FigureDetectOptions {
+    /// Minimum figure area as fraction of page area (default: 0.02 = 2%)
+    pub min_area_fraction: f32,
+    /// Maximum aspect ratio for valid figures (default: 10.0)
+    pub max_aspect_ratio: f32,
+    /// Text coverage threshold for full-page image classification (default: 0.05 = 5%)
+    pub fullpage_text_threshold: f32,
+    /// Text coverage threshold for text-only classification (default: 0.80 = 80%)
+    pub textonly_text_threshold: f32,
+    /// Dilation kernel size for text region merging (default: 15)
+    pub dilation_size: u32,
+    /// Binarization threshold (default: 200)
+    pub binary_threshold: u8,
+}
+
+impl Default for FigureDetectOptions {
+    fn default() -> Self {
+        Self {
+            min_area_fraction: 0.02,
+            max_aspect_ratio: 10.0,
+            fullpage_text_threshold: 0.05,
+            textonly_text_threshold: 0.80,
+            dilation_size: 15,
+            binary_threshold: 200,
+        }
+    }
+}
+
+/// Figure detector for scanned book pages
+pub struct FigureDetector;
+
+impl FigureDetector {
+    /// Classify a page and detect figures based on OCR results
+    pub fn classify_page(
+        image: &DynamicImage,
+        ocr_result: &OcrResult,
+        page_index: usize,
+        options: &FigureDetectOptions,
+    ) -> PageClassification {
+        let (img_w, img_h) = (image.width(), image.height());
+        let page_area = (img_w as f64) * (img_h as f64);
+
+        if page_area == 0.0 {
+            return PageClassification::TextOnly;
+        }
+
+        // Calculate text coverage from OCR bounding boxes
+        let text_area = Self::calculate_text_area(&ocr_result.text_blocks, img_w, img_h);
+        let text_coverage = text_area as f64 / page_area;
+
+        // Cover: first page with very little text
+        if page_index == 0 && text_coverage < options.fullpage_text_threshold as f64 {
+            return PageClassification::Cover;
+        }
+
+        // Full-page image: very little text
+        if text_coverage < options.fullpage_text_threshold as f64 {
+            return PageClassification::FullPageImage;
+        }
+
+        // Text-only: mostly text
+        if text_coverage > options.textonly_text_threshold as f64 {
+            return PageClassification::TextOnly;
+        }
+
+        // Mixed: detect figure regions in non-text areas
+        let figures = Self::detect_figures(image, ocr_result, options);
+
+        if figures.is_empty() {
+            PageClassification::TextOnly
+        } else {
+            PageClassification::Mixed { figures }
+        }
+    }
+
+    /// Detect figure regions by analyzing non-text areas
+    fn detect_figures(
+        image: &DynamicImage,
+        ocr_result: &OcrResult,
+        options: &FigureDetectOptions,
+    ) -> Vec<FigureRegion> {
+        let (img_w, img_h) = (image.width(), image.height());
+        let page_area = (img_w as u64) * (img_h as u64);
+        let min_area = (page_area as f64 * options.min_area_fraction as f64) as u64;
+
+        // Create text mask: mark text regions as white (occupied)
+        let mut text_mask = GrayImage::new(img_w, img_h);
+        let dilation = options.dilation_size;
+
+        for block in &ocr_result.text_blocks {
+            let (bx, by, bw, bh) = block.bbox;
+            // Apply dilation to text regions (add margin)
+            let x_start = bx.saturating_sub(dilation);
+            let y_start = by.saturating_sub(dilation);
+            let x_end = (bx + bw + dilation).min(img_w);
+            let y_end = (by + bh + dilation).min(img_h);
+
+            for y in y_start..y_end {
+                for x in x_start..x_end {
+                    text_mask.put_pixel(x, y, Luma([255]));
+                }
+            }
+        }
+
+        // Binarize the original image (non-white = potential content)
+        let gray = image.to_luma8();
+        let mut content_mask = GrayImage::new(img_w, img_h);
+        for y in 0..img_h {
+            for x in 0..img_w {
+                let pixel = gray.get_pixel(x, y);
+                // Mark non-white pixels as content
+                if pixel[0] < options.binary_threshold {
+                    content_mask.put_pixel(x, y, Luma([255]));
+                }
+            }
+        }
+
+        // Non-text content: content that is NOT in text regions
+        let mut non_text_content = GrayImage::new(img_w, img_h);
+        for y in 0..img_h {
+            for x in 0..img_w {
+                let is_content = content_mask.get_pixel(x, y)[0] > 0;
+                let is_text = text_mask.get_pixel(x, y)[0] > 0;
+                if is_content && !is_text {
+                    non_text_content.put_pixel(x, y, Luma([255]));
+                }
+            }
+        }
+
+        // Find connected components using contours
+        let contours = find_contours::<u32>(&non_text_content);
+
+        // Extract bounding boxes from contours
+        let mut figures = Vec::new();
+
+        for contour in &contours {
+            if contour.border_type == BorderType::Hole {
+                continue;
+            }
+
+            if contour.points.is_empty() {
+                continue;
+            }
+
+            let mut min_x = u32::MAX;
+            let mut min_y = u32::MAX;
+            let mut max_x = 0u32;
+            let mut max_y = 0u32;
+
+            for p in &contour.points {
+                min_x = min_x.min(p.x);
+                min_y = min_y.min(p.y);
+                max_x = max_x.max(p.x);
+                max_y = max_y.max(p.y);
+            }
+
+            let w = max_x.saturating_sub(min_x);
+            let h = max_y.saturating_sub(min_y);
+            let area = (w as u64) * (h as u64);
+
+            // Filter by area
+            if area < min_area {
+                continue;
+            }
+
+            // Filter by aspect ratio
+            if w > 0 && h > 0 {
+                let aspect = if w > h {
+                    w as f32 / h as f32
+                } else {
+                    h as f32 / w as f32
+                };
+                if aspect > options.max_aspect_ratio {
+                    continue;
+                }
+            }
+
+            figures.push(FigureRegion {
+                bbox: (min_x, min_y, w, h),
+                area: area as u32,
+                region_type: RegionType::Figure,
+            });
+        }
+
+        // Merge overlapping figure regions
+        Self::merge_overlapping(&mut figures);
+
+        figures
+    }
+
+    /// Calculate total text area from OCR text blocks, clamped to image bounds
+    fn calculate_text_area(blocks: &[TextBlock], img_w: u32, img_h: u32) -> u64 {
+        let mut total = 0u64;
+        for block in blocks {
+            let (bx, by, bw, bh) = block.bbox;
+            let w = bw.min(img_w.saturating_sub(bx));
+            let h = bh.min(img_h.saturating_sub(by));
+            total += (w as u64) * (h as u64);
+        }
+        total
+    }
+
+    /// Merge overlapping figure regions
+    fn merge_overlapping(figures: &mut Vec<FigureRegion>) {
+        if figures.len() <= 1 {
+            return;
+        }
+
+        let mut merged = true;
+        while merged {
+            merged = false;
+            let mut i = 0;
+            while i < figures.len() {
+                let mut j = i + 1;
+                while j < figures.len() {
+                    if Self::regions_overlap(&figures[i], &figures[j]) {
+                        // Merge j into i
+                        let a = &figures[i];
+                        let b = &figures[j];
+                        let x1 = a.bbox.0.min(b.bbox.0);
+                        let y1 = a.bbox.1.min(b.bbox.1);
+                        let x2 = (a.bbox.0 + a.bbox.2).max(b.bbox.0 + b.bbox.2);
+                        let y2 = (a.bbox.1 + a.bbox.3).max(b.bbox.1 + b.bbox.3);
+                        let w = x2 - x1;
+                        let h = y2 - y1;
+                        figures[i] = FigureRegion {
+                            bbox: (x1, y1, w, h),
+                            area: w * h,
+                            region_type: RegionType::Figure,
+                        };
+                        figures.remove(j);
+                        merged = true;
+                    } else {
+                        j += 1;
+                    }
+                }
+                i += 1;
+            }
+        }
+    }
+
+    /// Check if two regions overlap
+    fn regions_overlap(a: &FigureRegion, b: &FigureRegion) -> bool {
+        let a_right = a.bbox.0 + a.bbox.2;
+        let a_bottom = a.bbox.1 + a.bbox.3;
+        let b_right = b.bbox.0 + b.bbox.2;
+        let b_bottom = b.bbox.1 + b.bbox.3;
+
+        a.bbox.0 < b_right && a_right > b.bbox.0 && a.bbox.1 < b_bottom && a_bottom > b.bbox.1
+    }
+
+    /// Crop a figure region from the source image
+    pub fn crop_figure(image: &DynamicImage, region: &FigureRegion) -> DynamicImage {
+        let (x, y, w, h) = region.bbox;
+        // Add 3% margin
+        let margin_x = (w as f32 * 0.03) as u32;
+        let margin_y = (h as f32 * 0.03) as u32;
+
+        let crop_x = x.saturating_sub(margin_x);
+        let crop_y = y.saturating_sub(margin_y);
+        let crop_w = (w + margin_x * 2).min(image.width().saturating_sub(crop_x));
+        let crop_h = (h + margin_y * 2).min(image.height().saturating_sub(crop_y));
+
+        image.crop_imm(crop_x, crop_y, crop_w, crop_h)
+    }
+
+    /// Detect the actual content bounding box of an image by finding non-white pixels.
+    /// Returns `(x, y, width, height)` of the content area, or `None` if the image is blank.
+    /// `threshold` controls what counts as "white" (default ~240).
+    pub fn find_content_bounds(image: &DynamicImage, threshold: u8) -> Option<(u32, u32, u32, u32)> {
+        let gray = image.to_luma8();
+        let (img_w, img_h) = (gray.width(), gray.height());
+
+        let mut min_x = img_w;
+        let mut min_y = img_h;
+        let mut max_x = 0u32;
+        let mut max_y = 0u32;
+
+        for y in 0..img_h {
+            for x in 0..img_w {
+                if gray.get_pixel(x, y)[0] < threshold {
+                    min_x = min_x.min(x);
+                    min_y = min_y.min(y);
+                    max_x = max_x.max(x);
+                    max_y = max_y.max(y);
+                }
+            }
+        }
+
+        if max_x < min_x || max_y < min_y {
+            return None; // Blank image
+        }
+
+        let w = max_x - min_x + 1;
+        let h = max_y - min_y + 1;
+        Some((min_x, min_y, w, h))
+    }
+
+    /// Crop an image to its actual content area, removing white margins.
+    /// Adds a small padding (1% of content size) around the detected content.
+    /// Returns the original image if no content bounds are detected.
+    pub fn crop_to_content(image: &DynamicImage, threshold: u8) -> DynamicImage {
+        let bounds = match Self::find_content_bounds(image, threshold) {
+            Some(b) => b,
+            None => return image.clone(),
+        };
+
+        let (x, y, w, h) = bounds;
+
+        // Add 1% padding around the content
+        let pad_x = (w as f32 * 0.01).ceil() as u32;
+        let pad_y = (h as f32 * 0.01).ceil() as u32;
+
+        let crop_x = x.saturating_sub(pad_x);
+        let crop_y = y.saturating_sub(pad_y);
+        let crop_w = (w + pad_x * 2).min(image.width().saturating_sub(crop_x));
+        let crop_h = (h + pad_y * 2).min(image.height().saturating_sub(crop_y));
+
+        image.crop_imm(crop_x, crop_y, crop_w, crop_h)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::yomitoku::TextDirection;
+    use std::time::Duration;
+
+    fn make_ocr_result(blocks: Vec<TextBlock>) -> OcrResult {
+        OcrResult {
+            input_path: "test.png".into(),
+            text_blocks: blocks,
+            confidence: 0.9,
+            processing_time: Duration::from_millis(100),
+            text_direction: TextDirection::Vertical,
+        }
+    }
+
+    #[test]
+    fn test_classify_text_only_page() {
+        let img = DynamicImage::new_rgb8(1000, 1500);
+        let blocks = vec![TextBlock {
+            text: "テスト".into(),
+            bbox: (50, 50, 900, 1350),
+            confidence: 0.95,
+            direction: TextDirection::Vertical,
+            font_size: Some(12.0),
+        }];
+        let ocr = make_ocr_result(blocks);
+        let opts = FigureDetectOptions::default();
+
+        let result = FigureDetector::classify_page(&img, &ocr, 1, &opts);
+        assert!(matches!(result, PageClassification::TextOnly));
+    }
+
+    #[test]
+    fn test_classify_cover_page() {
+        let img = DynamicImage::new_rgb8(1000, 1500);
+        let ocr = make_ocr_result(vec![]);
+        let opts = FigureDetectOptions::default();
+
+        let result = FigureDetector::classify_page(&img, &ocr, 0, &opts);
+        assert!(matches!(result, PageClassification::Cover));
+    }
+
+    #[test]
+    fn test_classify_fullpage_image() {
+        let img = DynamicImage::new_rgb8(1000, 1500);
+        let ocr = make_ocr_result(vec![]);
+        let opts = FigureDetectOptions::default();
+
+        // Page index > 0, no text -> FullPageImage
+        let result = FigureDetector::classify_page(&img, &ocr, 5, &opts);
+        assert!(matches!(result, PageClassification::FullPageImage));
+    }
+
+    #[test]
+    fn test_regions_overlap() {
+        let a = FigureRegion {
+            bbox: (0, 0, 100, 100),
+            area: 10000,
+            region_type: RegionType::Figure,
+        };
+        let b = FigureRegion {
+            bbox: (50, 50, 100, 100),
+            area: 10000,
+            region_type: RegionType::Figure,
+        };
+        assert!(FigureDetector::regions_overlap(&a, &b));
+
+        let c = FigureRegion {
+            bbox: (200, 200, 100, 100),
+            area: 10000,
+            region_type: RegionType::Figure,
+        };
+        assert!(!FigureDetector::regions_overlap(&a, &c));
+    }
+
+    #[test]
+    fn test_figure_detect_options_default() {
+        let opts = FigureDetectOptions::default();
+        assert!((opts.min_area_fraction - 0.02).abs() < f32::EPSILON);
+        assert!((opts.max_aspect_ratio - 10.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_crop_figure() {
+        let img = DynamicImage::new_rgb8(500, 500);
+        let region = FigureRegion {
+            bbox: (100, 100, 200, 200),
+            area: 40000,
+            region_type: RegionType::Figure,
+        };
+        let cropped = FigureDetector::crop_figure(&img, &region);
+        assert!(cropped.width() > 0);
+        assert!(cropped.height() > 0);
+    }
+
+    #[test]
+    fn test_find_content_bounds_blank_image() {
+        use image::{Rgb, RgbImage};
+        // All-white image should return None
+        let raw = RgbImage::from_pixel(100, 100, Rgb([255, 255, 255]));
+        let img = DynamicImage::ImageRgb8(raw);
+        assert!(FigureDetector::find_content_bounds(&img, 240).is_none());
+    }
+
+    #[test]
+    fn test_find_content_bounds_with_content() {
+        use image::{Rgb, RgbImage};
+        let mut raw = RgbImage::from_pixel(200, 200, Rgb([255, 255, 255]));
+        // Draw a black rectangle at (50,60) to (120,140)
+        for y in 60..=140 {
+            for x in 50..=120 {
+                raw.put_pixel(x, y, Rgb([0, 0, 0]));
+            }
+        }
+        let img = DynamicImage::ImageRgb8(raw);
+        let bounds = FigureDetector::find_content_bounds(&img, 240).unwrap();
+        assert_eq!(bounds, (50, 60, 71, 81));
+    }
+
+    #[test]
+    fn test_crop_to_content() {
+        use image::{Rgb, RgbImage};
+        let mut raw = RgbImage::from_pixel(500, 500, Rgb([255, 255, 255]));
+        // Draw content in center area (100,100) to (399,399)
+        for y in 100..400 {
+            for x in 100..400 {
+                raw.put_pixel(x, y, Rgb([50, 50, 50]));
+            }
+        }
+        let img = DynamicImage::ImageRgb8(raw);
+        let cropped = FigureDetector::crop_to_content(&img, 240);
+        // Cropped image should be roughly 300x300 + small padding, much smaller than 500x500
+        assert!(cropped.width() < 320);
+        assert!(cropped.height() < 320);
+        assert!(cropped.width() >= 300);
+        assert!(cropped.height() >= 300);
+    }
+}

--- a/superbook-pdf/src/lib.rs
+++ b/superbook-pdf/src/lib.rs
@@ -123,9 +123,12 @@ pub mod cli;
 pub mod config;
 pub mod color_stats;
 pub mod deskew;
+pub mod figure_detect;
 pub mod finalize;
 pub mod image_extract;
 pub mod margin;
+pub mod markdown_gen;
+pub mod markdown_pipeline;
 pub mod normalize;
 pub mod page_number;
 pub mod parallel;
@@ -218,6 +221,14 @@ pub use progress::{build_progress_bar, OutputMode, ProcessingStage, ProgressTrac
 pub use cache::{
     should_skip_processing, CacheDigest, ProcessingCache, ProcessingResult, CACHE_EXTENSION,
     CACHE_VERSION,
+};
+pub use figure_detect::{
+    FigureDetectError, FigureDetectOptions, FigureDetector, FigureRegion, PageClassification,
+    RegionType,
+};
+pub use markdown_gen::{ContentElement, MarkdownGenError, MarkdownGenerator, PageContent};
+pub use markdown_pipeline::{
+    MarkdownPipeline, MarkdownPipelineError, MarkdownPipelineResult, ProgressState,
 };
 pub use pipeline::{
     calculate_optimal_chunk_size, process_in_chunks, PdfPipeline, PipelineConfig, PipelineError,

--- a/superbook-pdf/src/markdown_gen.rs
+++ b/superbook-pdf/src/markdown_gen.rs
@@ -1,0 +1,463 @@
+//! Markdown generation module
+//!
+//! Generates Markdown files from OCR results and detected figures.
+//! Supports page-by-page generation with final merge.
+
+use std::fmt::Write as FmtWrite;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+use crate::figure_detect::{PageClassification, FigureRegion};
+use crate::yomitoku::{OcrResult, TextBlock, TextDirection};
+
+/// Error type for Markdown generation
+#[derive(Debug, Error)]
+pub enum MarkdownGenError {
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("Output directory not writable: {0}")]
+    OutputNotWritable(PathBuf),
+
+    #[error("Generation error: {0}")]
+    GenerationError(String),
+}
+
+/// A content element within a page
+#[derive(Debug, Clone)]
+pub enum ContentElement {
+    /// Text content with direction info
+    Text {
+        content: String,
+        direction: TextDirection,
+    },
+    /// Figure image reference
+    Figure {
+        image_path: PathBuf,
+        caption: Option<String>,
+    },
+    /// Full-page image (cover or illustration)
+    FullPageImage {
+        image_path: PathBuf,
+    },
+    /// Page break separator
+    PageBreak,
+}
+
+/// Processed content for a single page
+#[derive(Debug, Clone)]
+pub struct PageContent {
+    pub page_index: usize,
+    pub elements: Vec<ContentElement>,
+}
+
+/// Markdown generator
+pub struct MarkdownGenerator {
+    output_dir: PathBuf,
+    images_dir: PathBuf,
+    pages_dir: PathBuf,
+}
+
+impl MarkdownGenerator {
+    /// Create a new generator with output directories
+    pub fn new(output_dir: &Path) -> Result<Self, MarkdownGenError> {
+        let images_dir = output_dir.join("images");
+        let pages_dir = output_dir.join("pages");
+
+        std::fs::create_dir_all(&images_dir)?;
+        std::fs::create_dir_all(&pages_dir)?;
+
+        Ok(Self {
+            output_dir: output_dir.to_path_buf(),
+            images_dir,
+            pages_dir,
+        })
+    }
+
+    /// Generate Markdown for a single page
+    pub fn generate_page_markdown(
+        &self,
+        page_content: &PageContent,
+    ) -> Result<String, MarkdownGenError> {
+        let mut md = String::new();
+
+        for element in &page_content.elements {
+            match element {
+                ContentElement::Text { content, .. } => {
+                    // Write text content, preserving paragraphs
+                    for paragraph in content.split("\n\n") {
+                        let trimmed = paragraph.trim();
+                        if !trimmed.is_empty() {
+                            writeln!(md, "{}", trimmed).ok();
+                            writeln!(md).ok();
+                        }
+                    }
+                }
+                ContentElement::Figure { image_path, caption } => {
+                    let rel_path = self.relative_image_path(image_path);
+                    match caption {
+                        Some(cap) => writeln!(md, "![{}]({})", cap, rel_path).ok(),
+                        None => writeln!(md, "![図]({})", rel_path).ok(),
+                    };
+                    writeln!(md).ok();
+                }
+                ContentElement::FullPageImage { image_path } => {
+                    let rel_path = self.relative_image_path(image_path);
+                    writeln!(md, "![]({})", rel_path).ok();
+                    writeln!(md).ok();
+                }
+                ContentElement::PageBreak => {
+                    writeln!(md, "---").ok();
+                    writeln!(md).ok();
+                }
+            }
+        }
+
+        Ok(md)
+    }
+
+    /// Save page markdown to pages directory
+    pub fn save_page_markdown(
+        &self,
+        page_index: usize,
+        content: &str,
+    ) -> Result<PathBuf, MarkdownGenError> {
+        let page_path = self.pages_dir.join(format!("page_{:03}.md", page_index + 1));
+        std::fs::write(&page_path, content)?;
+        Ok(page_path)
+    }
+
+    /// Build PageContent from OCR result and page classification
+    pub fn build_page_content(
+        &self,
+        page_index: usize,
+        ocr_result: &OcrResult,
+        classification: &PageClassification,
+        figure_images: &[(FigureRegion, PathBuf)],
+    ) -> PageContent {
+        let mut elements = Vec::new();
+
+        match classification {
+            PageClassification::Cover => {
+                // Look for a saved cover image
+                let cover_path = self.images_dir.join(format!("cover_{:03}.png", page_index + 1));
+                elements.push(ContentElement::FullPageImage {
+                    image_path: cover_path,
+                });
+            }
+            PageClassification::FullPageImage => {
+                let img_path = self.images_dir.join(format!(
+                    "page_{:03}_full.png",
+                    page_index + 1
+                ));
+                elements.push(ContentElement::FullPageImage {
+                    image_path: img_path,
+                });
+            }
+            PageClassification::TextOnly => {
+                let text = Self::sort_and_join_text_blocks(&ocr_result.text_blocks, &ocr_result.text_direction);
+                if !text.is_empty() {
+                    elements.push(ContentElement::Text {
+                        content: text,
+                        direction: ocr_result.text_direction,
+                    });
+                }
+            }
+            PageClassification::Mixed { figures } => {
+                // Sort text blocks by reading order
+                let sorted_blocks =
+                    Self::sort_text_blocks(&ocr_result.text_blocks, &ocr_result.text_direction);
+
+                // Interleave text and figures based on vertical position
+                let mut figure_idx = 0;
+                let mut current_text = String::new();
+
+                for block in &sorted_blocks {
+                    // Check if any figure should be inserted before this text block
+                    while figure_idx < figures.len() {
+                        let fig = &figures[figure_idx];
+                        let fig_y = fig.bbox.1;
+                        let block_y = block.bbox.1;
+
+                        if fig_y < block_y {
+                            // Insert accumulated text
+                            if !current_text.is_empty() {
+                                elements.push(ContentElement::Text {
+                                    content: std::mem::take(&mut current_text),
+                                    direction: ocr_result.text_direction,
+                                });
+                            }
+
+                            // Insert figure
+                            if let Some((_, fig_path)) = figure_images.get(figure_idx) {
+                                elements.push(ContentElement::Figure {
+                                    image_path: fig_path.clone(),
+                                    caption: None,
+                                });
+                            }
+                            figure_idx += 1;
+                        } else {
+                            break;
+                        }
+                    }
+
+                    // Accumulate text
+                    if !current_text.is_empty() {
+                        current_text.push('\n');
+                    }
+                    current_text.push_str(&block.text);
+                }
+
+                // Flush remaining text
+                if !current_text.is_empty() {
+                    elements.push(ContentElement::Text {
+                        content: current_text,
+                        direction: ocr_result.text_direction,
+                    });
+                }
+
+                // Flush remaining figures
+                while figure_idx < figures.len() {
+                    if let Some((_, fig_path)) = figure_images.get(figure_idx) {
+                        elements.push(ContentElement::Figure {
+                            image_path: fig_path.clone(),
+                            caption: None,
+                        });
+                    }
+                    figure_idx += 1;
+                }
+            }
+        }
+
+        // Add page break
+        elements.push(ContentElement::PageBreak);
+
+        PageContent {
+            page_index,
+            elements,
+        }
+    }
+
+    /// Merge all page markdowns into a single output file
+    pub fn merge_pages(&self, title: &str, total_pages: usize) -> Result<PathBuf, MarkdownGenError> {
+        let output_path = self.output_dir.join(format!("{}.md", sanitize_filename(title)));
+        let mut merged = String::new();
+
+        // Title header
+        writeln!(merged, "# {}", title).ok();
+        writeln!(merged).ok();
+
+        // Concatenate page files in order
+        for i in 0..total_pages {
+            let page_path = self.pages_dir.join(format!("page_{:03}.md", i + 1));
+            if page_path.exists() {
+                let content = std::fs::read_to_string(&page_path)?;
+                merged.push_str(&content);
+            }
+        }
+
+        std::fs::write(&output_path, &merged)?;
+        Ok(output_path)
+    }
+
+    /// Get images directory path
+    pub fn images_dir(&self) -> &Path {
+        &self.images_dir
+    }
+
+    /// Get pages directory path
+    pub fn pages_dir(&self) -> &Path {
+        &self.pages_dir
+    }
+
+    /// Sort text blocks by reading order and join into a single string
+    fn sort_and_join_text_blocks(blocks: &[TextBlock], direction: &TextDirection) -> String {
+        let sorted = Self::sort_text_blocks(blocks, direction);
+        let mut result = String::new();
+        for block in &sorted {
+            if !result.is_empty() {
+                result.push('\n');
+            }
+            result.push_str(&block.text);
+        }
+        result
+    }
+
+    /// Sort text blocks by reading order
+    /// Vertical (Japanese): right-to-left columns, then top-to-bottom within each column
+    /// Horizontal: top-to-bottom rows, then left-to-right within each row
+    fn sort_text_blocks(blocks: &[TextBlock], direction: &TextDirection) -> Vec<TextBlock> {
+        let mut sorted = blocks.to_vec();
+
+        match direction {
+            TextDirection::Vertical => {
+                // Right-to-left, then top-to-bottom
+                sorted.sort_by(|a, b| {
+                    // Compare X in reverse (right to left)
+                    let ax = a.bbox.0;
+                    let bx = b.bbox.0;
+                    let x_cmp = bx.cmp(&ax);
+                    if x_cmp != std::cmp::Ordering::Equal {
+                        return x_cmp;
+                    }
+                    // Then top to bottom
+                    a.bbox.1.cmp(&b.bbox.1)
+                });
+            }
+            TextDirection::Horizontal | TextDirection::Mixed => {
+                // Top-to-bottom, then left-to-right
+                sorted.sort_by(|a, b| {
+                    let ay = a.bbox.1;
+                    let by = b.bbox.1;
+                    let y_cmp = ay.cmp(&by);
+                    if y_cmp != std::cmp::Ordering::Equal {
+                        return y_cmp;
+                    }
+                    a.bbox.0.cmp(&b.bbox.0)
+                });
+            }
+        }
+
+        sorted
+    }
+
+    /// Get image path relative to the output directory for markdown references
+    fn relative_image_path(&self, abs_path: &Path) -> String {
+        if let Ok(rel) = abs_path.strip_prefix(&self.output_dir) {
+            rel.to_string_lossy().to_string()
+        } else {
+            abs_path.to_string_lossy().to_string()
+        }
+    }
+}
+
+/// Sanitize a string for use as a filename
+fn sanitize_filename(name: &str) -> String {
+    name.chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            _ => c,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_filename() {
+        assert_eq!(sanitize_filename("hello/world"), "hello_world");
+        assert_eq!(sanitize_filename("test:file"), "test_file");
+        assert_eq!(sanitize_filename("normal_file"), "normal_file");
+        assert_eq!(sanitize_filename("日本語テスト"), "日本語テスト");
+    }
+
+    #[test]
+    fn test_sort_text_blocks_vertical() {
+        let blocks = vec![
+            TextBlock {
+                text: "左列".into(),
+                bbox: (100, 0, 50, 500),
+                confidence: 0.9,
+                direction: TextDirection::Vertical,
+                font_size: Some(12.0),
+            },
+            TextBlock {
+                text: "右列".into(),
+                bbox: (500, 0, 50, 500),
+                confidence: 0.9,
+                direction: TextDirection::Vertical,
+                font_size: Some(12.0),
+            },
+        ];
+
+        let sorted = MarkdownGenerator::sort_text_blocks(&blocks, &TextDirection::Vertical);
+        assert_eq!(sorted[0].text, "右列"); // Right column first
+        assert_eq!(sorted[1].text, "左列"); // Left column second
+    }
+
+    #[test]
+    fn test_sort_text_blocks_horizontal() {
+        let blocks = vec![
+            TextBlock {
+                text: "下行".into(),
+                bbox: (0, 500, 200, 50),
+                confidence: 0.9,
+                direction: TextDirection::Horizontal,
+                font_size: Some(12.0),
+            },
+            TextBlock {
+                text: "上行".into(),
+                bbox: (0, 100, 200, 50),
+                confidence: 0.9,
+                direction: TextDirection::Horizontal,
+                font_size: Some(12.0),
+            },
+        ];
+
+        let sorted = MarkdownGenerator::sort_text_blocks(&blocks, &TextDirection::Horizontal);
+        assert_eq!(sorted[0].text, "上行");
+        assert_eq!(sorted[1].text, "下行");
+    }
+
+    #[test]
+    fn test_generate_page_markdown_text() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let gen = MarkdownGenerator::new(tmpdir.path()).unwrap();
+
+        let content = PageContent {
+            page_index: 0,
+            elements: vec![
+                ContentElement::Text {
+                    content: "テスト段落です。".into(),
+                    direction: TextDirection::Vertical,
+                },
+                ContentElement::PageBreak,
+            ],
+        };
+
+        let md = gen.generate_page_markdown(&content).unwrap();
+        assert!(md.contains("テスト段落です。"));
+        assert!(md.contains("---"));
+    }
+
+    #[test]
+    fn test_generate_page_markdown_figure() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let gen = MarkdownGenerator::new(tmpdir.path()).unwrap();
+        let img_path = tmpdir.path().join("images").join("fig.png");
+
+        let content = PageContent {
+            page_index: 0,
+            elements: vec![
+                ContentElement::Figure {
+                    image_path: img_path,
+                    caption: Some("テスト図".into()),
+                },
+                ContentElement::PageBreak,
+            ],
+        };
+
+        let md = gen.generate_page_markdown(&content).unwrap();
+        assert!(md.contains("![テスト図]"));
+        assert!(md.contains("images/fig.png"));
+    }
+
+    #[test]
+    fn test_save_and_merge_pages() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let gen = MarkdownGenerator::new(tmpdir.path()).unwrap();
+
+        gen.save_page_markdown(0, "Page 1 content\n\n---\n\n").unwrap();
+        gen.save_page_markdown(1, "Page 2 content\n\n---\n\n").unwrap();
+
+        let merged_path = gen.merge_pages("テストブック", 2).unwrap();
+        assert!(merged_path.exists());
+
+        let content = std::fs::read_to_string(&merged_path).unwrap();
+        assert!(content.contains("# テストブック"));
+        assert!(content.contains("Page 1 content"));
+        assert!(content.contains("Page 2 content"));
+    }
+}

--- a/superbook-pdf/src/markdown_pipeline.rs
+++ b/superbook-pdf/src/markdown_pipeline.rs
@@ -1,0 +1,644 @@
+//! Markdown conversion pipeline
+//!
+//! Provides a pipeline for converting scanned PDFs to Markdown,
+//! reusing existing processing steps (extraction, deskew, upscale)
+//! and adding OCR + figure detection + Markdown generation.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+use thiserror::Error;
+
+use crate::cli::MarkdownArgs;
+use crate::figure_detect::{FigureDetectOptions, FigureDetector, FigureRegion, PageClassification};
+use crate::markdown_gen::{MarkdownGenError, MarkdownGenerator};
+use crate::pipeline::{PipelineConfig, PipelineError, ProgressCallback};
+use crate::yomitoku::{OcrResult, YomiTokuOptions};
+
+/// Error type for Markdown pipeline
+#[derive(Debug, Error)]
+pub enum MarkdownPipelineError {
+    #[error("Input file not found: {0}")]
+    InputNotFound(PathBuf),
+
+    #[error("Pipeline error: {0}")]
+    Pipeline(#[from] PipelineError),
+
+    #[error("Markdown generation error: {0}")]
+    MarkdownGen(#[from] MarkdownGenError),
+
+    #[error("OCR error: {0}")]
+    OcrError(String),
+
+    #[error("Figure detection error: {0}")]
+    FigureDetectError(String),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+/// Progress state for recovery
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProgressState {
+    pub total_pages: usize,
+    pub processed_pages: Vec<usize>,
+    pub started_at: String,
+    pub last_updated: String,
+    pub input_pdf: PathBuf,
+    pub title: String,
+}
+
+impl ProgressState {
+    fn new(total_pages: usize, input_pdf: &Path, title: &str) -> Self {
+        let now = chrono::Utc::now().to_rfc3339();
+        Self {
+            total_pages,
+            processed_pages: Vec::new(),
+            started_at: now.clone(),
+            last_updated: now,
+            input_pdf: input_pdf.to_path_buf(),
+            title: title.to_string(),
+        }
+    }
+
+    fn mark_processed(&mut self, page_index: usize) {
+        if !self.processed_pages.contains(&page_index) {
+            self.processed_pages.push(page_index);
+            self.processed_pages.sort();
+        }
+        self.last_updated = chrono::Utc::now().to_rfc3339();
+    }
+
+    fn is_processed(&self, page_index: usize) -> bool {
+        self.processed_pages.contains(&page_index)
+    }
+
+    fn save(&self, path: &Path) -> Result<(), MarkdownPipelineError> {
+        let json = serde_json::to_string_pretty(self)?;
+        std::fs::write(path, json)?;
+        Ok(())
+    }
+
+    fn load(path: &Path) -> Result<Self, MarkdownPipelineError> {
+        let json = std::fs::read_to_string(path)?;
+        let state: Self = serde_json::from_str(&json)?;
+        Ok(state)
+    }
+}
+
+/// Result of Markdown pipeline processing
+#[derive(Debug)]
+pub struct MarkdownPipelineResult {
+    pub page_count: usize,
+    pub output_path: PathBuf,
+    pub images_count: usize,
+    pub elapsed_seconds: f64,
+}
+
+/// Markdown conversion pipeline
+pub struct MarkdownPipeline {
+    config: PipelineConfig,
+    figure_options: FigureDetectOptions,
+}
+
+impl MarkdownPipeline {
+    /// Create a new Markdown pipeline from CLI args
+    pub fn from_args(args: &MarkdownArgs) -> Self {
+        let config = PipelineConfig {
+            dpi: args.dpi,
+            deskew: args.effective_deskew(),
+            margin_trim: 0.5,
+            upscale: args.upscale,
+            gpu: args.gpu,
+            ocr: true, // Always enabled for Markdown
+            max_pages: args.max_pages,
+            save_debug: args.verbose >= 3,
+            ..PipelineConfig::default()
+        };
+
+        let mut figure_options = FigureDetectOptions::default();
+        if let Some(sensitivity) = args.figure_sensitivity {
+            // Lower min_area_fraction = more sensitive
+            figure_options.min_area_fraction = 0.05 * (1.0 - sensitivity.clamp(0.0, 1.0));
+        }
+
+        Self {
+            config,
+            figure_options,
+        }
+    }
+
+    /// Run the full Markdown conversion pipeline
+    pub fn run<P: ProgressCallback>(
+        &self,
+        input: &Path,
+        output_dir: &Path,
+        resume: bool,
+        progress: &P,
+    ) -> Result<MarkdownPipelineResult, MarkdownPipelineError> {
+        let start_time = Instant::now();
+
+        // Validate input
+        if !input.exists() {
+            return Err(MarkdownPipelineError::InputNotFound(input.to_path_buf()));
+        }
+
+        // Create output directory structure
+        std::fs::create_dir_all(output_dir)?;
+        let progress_path = output_dir.join(".progress.json");
+
+        // Determine title from filename
+        let title = input
+            .file_stem()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+
+        // Create work directory for intermediate files
+        let work_dir = output_dir.join(format!(".work_{}", &title));
+        std::fs::create_dir_all(&work_dir)?;
+
+        // Step 1: Extract images from PDF
+        progress.on_step_start("PDF画像抽出中...");
+        let extract_options = crate::ExtractOptions::builder()
+            .dpi(self.config.dpi)
+            .build();
+        let extracted_dir = work_dir.join("extracted");
+        std::fs::create_dir_all(&extracted_dir)?;
+
+        let mut extracted_pages =
+            crate::LopdfExtractor::extract_auto(input, &extracted_dir, &extract_options)
+                .map_err(|e| PipelineError::ExtractionFailed(e.to_string()))?;
+
+        // Apply max_pages limit
+        if let Some(max_pages) = self.config.max_pages {
+            if extracted_pages.len() > max_pages {
+                progress.on_debug(&format!("{}ページに制限", max_pages));
+                extracted_pages.truncate(max_pages);
+            }
+        }
+
+        let page_count = extracted_pages.len();
+        progress.on_step_complete("PDF画像抽出", &format!("{}ページ", page_count));
+
+        let mut current_images: Vec<PathBuf> =
+            extracted_pages.iter().map(|p| p.path.clone()).collect();
+
+        // Step 2: Margin trimming
+        if self.config.margin_trim > 0.0 {
+            progress.on_step_start("マージントリミング中...");
+            let trimmed_dir = work_dir.join("trimmed");
+            std::fs::create_dir_all(&trimmed_dir)?;
+
+            let trimmed = self.step_margin_trim(&trimmed_dir, &current_images, progress)?;
+            current_images = trimmed;
+            progress.on_step_complete("マージントリミング", "完了");
+        }
+
+        // Step 3: AI Upscaling (optional)
+        if self.config.upscale {
+            progress.on_step_start("AI超解像処理中...");
+            let upscaled_dir = work_dir.join("upscaled");
+            std::fs::create_dir_all(&upscaled_dir)?;
+
+            let upscaled = self.step_upscale(&upscaled_dir, &current_images, progress)?;
+            current_images = upscaled;
+            progress.on_step_complete("AI超解像", "完了");
+        }
+
+        // Step 4: Deskew
+        if self.config.deskew {
+            progress.on_step_start("傾き補正中...");
+            let deskewed_dir = work_dir.join("deskewed");
+            std::fs::create_dir_all(&deskewed_dir)?;
+
+            let deskewed = self.step_deskew(&deskewed_dir, &current_images, progress)?;
+            current_images = deskewed;
+            progress.on_step_complete("傾き補正", "完了");
+        }
+
+        // Load or create progress state
+        let mut state = if resume && progress_path.exists() {
+            let s = ProgressState::load(&progress_path)?;
+            // Validate that the resume state matches the current input PDF
+            if s.input_pdf != input {
+                progress.on_debug(&format!(
+                    "リカバリーstate不一致: 保存={}, 現在={} — 新規開始します",
+                    s.input_pdf.display(),
+                    input.display()
+                ));
+                ProgressState::new(page_count, input, &title)
+            } else {
+                progress.on_step_start(&format!(
+                    "リカバリーモード: {}/{}ページ処理済み",
+                    s.processed_pages.len(),
+                    s.total_pages
+                ));
+                // Filter out any processed_pages that exceed current page_count
+                let mut valid_state = s;
+                valid_state.processed_pages.retain(|&p| p < page_count);
+                valid_state.total_pages = page_count;
+                valid_state
+            }
+        } else {
+            ProgressState::new(page_count, input, &title)
+        };
+
+        // Create Markdown generator
+        let md_gen = MarkdownGenerator::new(output_dir)?;
+
+        // Step 5-9: OCR + Figure Detection + Markdown Generation (per page)
+        progress.on_step_start(&format!("OCR・図検出・Markdown生成 ({}ページ)...", page_count));
+
+        // Setup YomiToku (graceful fallback if venv unavailable)
+        let venv_path = std::env::var("SUPERBOOK_VENV")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("./ai_bridge/ai_venv"));
+        let bridge_config = crate::AiBridgeConfig::builder()
+            .venv_path(venv_path.clone())
+            .build();
+        let yomitoku = match crate::SubprocessBridge::new(bridge_config) {
+            Ok(bridge) => Some(crate::YomiToku::new(bridge)),
+            Err(e) => {
+                progress.on_debug(&format!(
+                    "YomiToku利用不可 (venvが見つからないか初期化失敗): {} — 図検出のみで続行します",
+                    e
+                ));
+                None
+            }
+        };
+
+        let yomitoku_options = YomiTokuOptions::builder()
+            .use_gpu(self.config.gpu)
+            .detect_vertical(true)
+            .confidence_threshold(0.3) // Lower threshold for book scanning
+            .build();
+
+        let mut images_count = 0usize;
+
+        for (page_idx, image_path) in current_images.iter().enumerate() {
+            // Skip already processed pages (resume mode)
+            if state.is_processed(page_idx) {
+                progress.on_debug(&format!("ページ {} スキップ (処理済み)", page_idx + 1));
+                continue;
+            }
+
+            progress.on_step_progress(page_idx + 1, page_count);
+
+            // Run OCR (or create empty result if YomiToku unavailable)
+            let ocr_result = if let Some(ref yt) = yomitoku {
+                match yt.ocr(image_path, &yomitoku_options) {
+                    Ok(result) => result,
+                    Err(e) => {
+                        progress.on_debug(&format!(
+                            "ページ {} OCRエラー: {} (空テキストとして続行)",
+                            page_idx + 1,
+                            e
+                        ));
+                        Self::empty_ocr_result(image_path)
+                    }
+                }
+            } else {
+                Self::empty_ocr_result(image_path)
+            };
+
+            // Load image for figure detection
+            let image = image::open(image_path)
+                .map_err(|e| MarkdownPipelineError::FigureDetectError(e.to_string()))?;
+
+            // Classify page and detect figures
+            let classification =
+                FigureDetector::classify_page(&image, &ocr_result, page_idx, &self.figure_options);
+
+            // Save figure/cover/full-page images
+            let figure_images = self.save_page_images(
+                &image,
+                page_idx,
+                &classification,
+                md_gen.images_dir(),
+            )?;
+            images_count += figure_images.len();
+
+            // Build page content
+            let page_content =
+                md_gen.build_page_content(page_idx, &ocr_result, &classification, &figure_images);
+
+            // Generate and save page Markdown
+            let page_md = md_gen.generate_page_markdown(&page_content)?;
+            md_gen.save_page_markdown(page_idx, &page_md)?;
+
+            // Update progress
+            state.mark_processed(page_idx);
+            state.save(&progress_path)?;
+
+            progress.on_debug(&format!(
+                "ページ {} 完了: {:?}",
+                page_idx + 1,
+                match &classification {
+                    PageClassification::Cover => "表紙",
+                    PageClassification::FullPageImage => "全面画像",
+                    PageClassification::TextOnly => "テキスト",
+                    PageClassification::Mixed { figures } =>
+                        if figures.is_empty() {
+                            "テキスト"
+                        } else {
+                            "テキスト+図"
+                        },
+                }
+            ));
+        }
+
+        progress.on_step_complete(
+            "OCR・図検出・Markdown生成",
+            &format!("{}ページ, {}画像", page_count, images_count),
+        );
+
+        // Step 10: Merge all page markdowns
+        progress.on_step_start("最終Markdown結合中...");
+        let output_path = md_gen.merge_pages(&title, page_count)?;
+        progress.on_step_complete("Markdown結合", &format!("{}", output_path.display()));
+
+        // Cleanup work directory
+        if !self.config.save_debug {
+            std::fs::remove_dir_all(&work_dir).ok();
+        }
+
+        let elapsed = start_time.elapsed().as_secs_f64();
+
+        Ok(MarkdownPipelineResult {
+            page_count,
+            output_path,
+            images_count,
+            elapsed_seconds: elapsed,
+        })
+    }
+
+    /// Save images for a page (covers, full-page images, figure crops)
+    /// Full-page images and covers are trimmed to their actual content area,
+    /// removing scan margins and white borders.
+    fn save_page_images(
+        &self,
+        image: &image::DynamicImage,
+        page_index: usize,
+        classification: &PageClassification,
+        images_dir: &Path,
+    ) -> Result<Vec<(FigureRegion, PathBuf)>, MarkdownPipelineError> {
+        let mut saved = Vec::new();
+        // Threshold for white detection (pixels brighter than this are "white")
+        let content_threshold: u8 = 240;
+
+        match classification {
+            PageClassification::Cover => {
+                let path = images_dir.join(format!("cover_{:03}.png", page_index + 1));
+                let trimmed = FigureDetector::crop_to_content(image, content_threshold);
+                trimmed
+                    .save(&path)
+                    .map_err(|e| MarkdownPipelineError::FigureDetectError(e.to_string()))?;
+                saved.push((
+                    FigureRegion {
+                        bbox: (0, 0, trimmed.width(), trimmed.height()),
+                        area: trimmed.width() * trimmed.height(),
+                        region_type: crate::figure_detect::RegionType::Cover,
+                    },
+                    path,
+                ));
+            }
+            PageClassification::FullPageImage => {
+                let path = images_dir.join(format!("page_{:03}_full.png", page_index + 1));
+                let trimmed = FigureDetector::crop_to_content(image, content_threshold);
+                trimmed
+                    .save(&path)
+                    .map_err(|e| MarkdownPipelineError::FigureDetectError(e.to_string()))?;
+                saved.push((
+                    FigureRegion {
+                        bbox: (0, 0, trimmed.width(), trimmed.height()),
+                        area: trimmed.width() * trimmed.height(),
+                        region_type: crate::figure_detect::RegionType::FullPageImage,
+                    },
+                    path,
+                ));
+            }
+            PageClassification::Mixed { figures } => {
+                for (fig_idx, figure) in figures.iter().enumerate() {
+                    let path = images_dir.join(format!(
+                        "page_{:03}_fig_{:03}.png",
+                        page_index + 1,
+                        fig_idx + 1
+                    ));
+                    let cropped = FigureDetector::crop_figure(image, figure);
+                    cropped
+                        .save(&path)
+                        .map_err(|e| MarkdownPipelineError::FigureDetectError(e.to_string()))?;
+                    saved.push((figure.clone(), path));
+                }
+            }
+            PageClassification::TextOnly => {}
+        }
+
+        Ok(saved)
+    }
+
+    /// Create an empty OCR result for fallback when YomiToku is unavailable
+    fn empty_ocr_result(image_path: &Path) -> OcrResult {
+        OcrResult {
+            input_path: image_path.to_path_buf(),
+            text_blocks: vec![],
+            confidence: 0.0,
+            processing_time: std::time::Duration::from_secs(0),
+            text_direction: crate::TextDirection::Vertical,
+        }
+    }
+
+    // ============ Reused pipeline steps ============
+
+    /// Margin trim step (reuses same logic as pipeline: simple fixed % crop)
+    fn step_margin_trim<P: ProgressCallback>(
+        &self,
+        output_dir: &Path,
+        images: &[PathBuf],
+        _progress: &P,
+    ) -> Result<Vec<PathBuf>, MarkdownPipelineError> {
+        let trim_percent = self.config.margin_trim / 100.0;
+        let mut output_paths = Vec::with_capacity(images.len());
+
+        for (idx, img_path) in images.iter().enumerate() {
+            let name = img_path
+                .file_name()
+                .map(|n| n.to_os_string())
+                .unwrap_or_else(|| format!("page_{:04}.png", idx).into());
+            let output_path = output_dir.join(&name);
+
+            if let Ok(img) = image::open(img_path) {
+                let (w, h) = (img.width(), img.height());
+                let trim_x = (w as f64 * trim_percent) as u32;
+                let trim_y = (h as f64 * trim_percent) as u32;
+                let new_w = w.saturating_sub(trim_x * 2);
+                let new_h = h.saturating_sub(trim_y * 2);
+
+                if new_w > 0 && new_h > 0 {
+                    let cropped = img.crop_imm(trim_x, trim_y, new_w, new_h);
+                    cropped.save(&output_path).ok();
+                } else {
+                    img.save(&output_path).ok();
+                }
+            } else {
+                std::fs::copy(img_path, &output_path)?;
+            }
+            output_paths.push(output_path);
+        }
+
+        Ok(output_paths)
+    }
+
+    /// Deskew step (reuses logic from pipeline)
+    fn step_deskew<P: ProgressCallback>(
+        &self,
+        output_dir: &Path,
+        images: &[PathBuf],
+        progress: &P,
+    ) -> Result<Vec<PathBuf>, MarkdownPipelineError> {
+        let deskew_options = crate::DeskewOptions::builder()
+            .algorithm(crate::DeskewAlgorithm::PageEdge)
+            .build();
+
+        let mut output_paths = Vec::with_capacity(images.len());
+
+        for (idx, img_path) in images.iter().enumerate() {
+            let name = img_path
+                .file_name()
+                .map(|n| n.to_os_string())
+                .unwrap_or_else(|| format!("page_{:04}.png", idx).into());
+            let output_path = output_dir.join(&name);
+
+            match crate::ImageProcDeskewer::deskew(img_path, &output_path, &deskew_options) {
+                Ok(_) => output_paths.push(output_path),
+                Err(e) => {
+                    progress.on_debug(&format!("傾き補正失敗 page {}: {}", idx, e));
+                    std::fs::copy(img_path, &output_path)?;
+                    output_paths.push(output_path);
+                }
+            }
+        }
+
+        Ok(output_paths)
+    }
+
+    /// AI upscale step (reuses same pattern as pipeline)
+    fn step_upscale<P: ProgressCallback>(
+        &self,
+        output_dir: &Path,
+        images: &[PathBuf],
+        progress: &P,
+    ) -> Result<Vec<PathBuf>, MarkdownPipelineError> {
+        let venv_path = std::env::var("SUPERBOOK_VENV")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("./ai_bridge/ai_venv"));
+
+        let bridge_config = crate::AiBridgeConfig::builder()
+            .venv_path(venv_path)
+            .build();
+
+        let bridge = match crate::SubprocessBridge::new(bridge_config) {
+            Ok(b) => b,
+            Err(e) => {
+                progress.on_debug(&format!("RealESRGAN利用不可: {}", e));
+                return Ok(images.to_vec());
+            }
+        };
+
+        let esrgan = crate::RealEsrgan::new(bridge);
+        let mut options = crate::RealEsrganOptions::builder().scale(2);
+        if self.config.gpu {
+            options = options.gpu_id(0);
+        }
+        let options = options.build();
+
+        match esrgan.upscale_batch(images, output_dir, &options, None) {
+            Ok(result) => {
+                progress.on_step_complete(
+                    "超解像",
+                    &format!("{}画像", result.successful.len()),
+                );
+                Ok(result
+                    .successful
+                    .iter()
+                    .map(|r| r.output_path.clone())
+                    .collect())
+            }
+            Err(e) => {
+                progress.on_debug(&format!("超解像失敗: {}", e));
+                Ok(images.to_vec())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_progress_state_new() {
+        let state = ProgressState::new(10, Path::new("test.pdf"), "test");
+        assert_eq!(state.total_pages, 10);
+        assert!(state.processed_pages.is_empty());
+        assert_eq!(state.title, "test");
+    }
+
+    #[test]
+    fn test_progress_state_mark_processed() {
+        let mut state = ProgressState::new(10, Path::new("test.pdf"), "test");
+        state.mark_processed(0);
+        state.mark_processed(5);
+        state.mark_processed(0); // Duplicate
+
+        assert!(state.is_processed(0));
+        assert!(state.is_processed(5));
+        assert!(!state.is_processed(3));
+        assert_eq!(state.processed_pages.len(), 2);
+    }
+
+    #[test]
+    fn test_progress_state_save_load() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("progress.json");
+
+        let mut state = ProgressState::new(10, Path::new("test.pdf"), "テスト");
+        state.mark_processed(0);
+        state.mark_processed(3);
+        state.save(&path).unwrap();
+
+        let loaded = ProgressState::load(&path).unwrap();
+        assert_eq!(loaded.total_pages, 10);
+        assert_eq!(loaded.processed_pages, vec![0, 3]);
+        assert_eq!(loaded.title, "テスト");
+    }
+
+    #[test]
+    fn test_markdown_pipeline_from_args() {
+        use clap::Parser;
+        use crate::cli::Cli;
+
+        let cli = Cli::try_parse_from([
+            "superbook-pdf",
+            "markdown",
+            "input.pdf",
+            "--dpi",
+            "300",
+            "--gpu",
+        ])
+        .unwrap();
+
+        if let crate::cli::Commands::Markdown(args) = cli.command {
+            let pipeline = MarkdownPipeline::from_args(&args);
+            assert_eq!(pipeline.config.dpi, 300);
+            assert!(pipeline.config.gpu);
+            assert!(pipeline.config.ocr);
+        } else {
+            panic!("Expected Markdown command");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- スキャン済みPDFからMarkdownへの変換パイプラインを実装
- `markdown`サブコマンドを追加（CLI）
- 図検出モジュール: 連結成分解析によるページ分類（表紙/全面画像/テキスト+図/テキスト）
- コンテンツ領域自動トリミング: スキャン余白を除去し写真・図版の実領域のみ抽出
- Markdown生成: 縦書き日本語の読み順ソート（右→左、上→下）
- 中断リカバリー対応（.progress.json + --resumeフラグ）

## New Files
- `src/figure_detect.rs` - 図検出 + コンテンツ領域トリミング
- `src/markdown_gen.rs` - Markdown生成・読み順ソート
- `src/markdown_pipeline.rs` - Markdown変換パイプライン

## Modified Files
- `src/cli.rs` - `markdown`サブコマンド定義
- `src/lib.rs` - 新モジュールexport
- `src/main.rs` - コマンドハンドラ追加

## Test plan
- [x] `cargo test figure_detect` - 9テスト全パス
- [x] イラク水滸伝.pdf 46ページ変換テスト完了（21画像、746秒）
- [x] 画像トリミング効果確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)